### PR TITLE
fix(website): Fix fatal error on website when user is logged in

### DIFF
--- a/trunk/Lib/Sidebar.php
+++ b/trunk/Lib/Sidebar.php
@@ -115,6 +115,7 @@ class Sidebar {
      * @return bool
      */
     private function isWpmlActive() {
+        require_once( ABSPATH . '/wp-admin/includes/plugin.php' );
         return is_plugin_active( 'sitepress-multilingual-cms/sitepress.php' );
     }
 

--- a/trunk/admin-quickbar.php
+++ b/trunk/admin-quickbar.php
@@ -22,7 +22,7 @@ use AdminQuickbar\Lib\Deactivator;
  * Plugin Name:       AdminQuickbar
  * Plugin URI:        https://github.com/RTO-Websites/Wordpress-AdminQuickbar
  * Description:       Adds a quickbar in admin with fast access to all posts/pages
- * Version:           1.7.1
+ * Version:           1.7.2
  * Author:            RTO GmbH
  * Author URI:        https://www.rto.de
  * License:           GPL-2.0+
@@ -36,7 +36,7 @@ if ( !defined( 'WPINC' ) ) {
     die;
 }
 
-define( 'AdminQuickbar_VERSION', '1.7.1' );
+define( 'AdminQuickbar_VERSION', '1.7.2' );
 
 define( 'AdminQuickbar_DIR', str_replace( '\\', '/', __DIR__ ) );
 define( 'AdminQuickbar_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
The function is_plugin_exists only exists in admin. So we have to include.
Other way would be something like this

```
return !empty(apply_filters( 'wpml_default_language', null ));
```

